### PR TITLE
Cleanup Duplicate Requests

### DIFF
--- a/src/components/Auth/OtpInput.tsx
+++ b/src/components/Auth/OtpInput.tsx
@@ -15,8 +15,8 @@ const OtpInput: React.FC<OtpInputProps> = ({ email, otpId }) => {
       // Verify OTP using the auth context
       const result = await verifyOtp(email, otp, otpId);
 
-      if ( result.success && result.credentialBundle ) {
-        authenticateUser(email, result.credentialBundle, setJwt, setAuthStep);
+      if ( result.success && result.data.credentialBundle ) {
+        authenticateUser(email, result.data.credentialBundle, setJwt, setAuthStep);
       }
     }
   };

--- a/src/components/Shared/Loader.tsx
+++ b/src/components/Shared/Loader.tsx
@@ -1,13 +1,18 @@
 // src/components/Loader.tsx
 import React from "react";
 import { useDevCredentials } from "../../context/DevCredentialsContext";
+import { useAuthContext } from "../../context/AuthContext";
 
 const Loader: React.FC = () => {
   const { credentialsLoading } = useDevCredentials(); // Get loading state and credentials from DevCredentialsContext
+  const { loading } = useAuthContext();
+
+  const loadingString = loading === true ? "Authenticating user..." : loading;
+
   return (
     <div className="flex flex-col items-center">
       <div className="text-lg mb-4">
-        {credentialsLoading ? "Waiting for credentials..." : "Authenticating user..."}
+        {credentialsLoading ? "Waiting for credentials..." : loadingString}
       </div>
       <div className="loader border-t-4 border-blue-500 rounded-full w-12 h-12 animate-spin"></div>
     </div>

--- a/src/components/Vehicles/VehicleManager.tsx
+++ b/src/components/Vehicles/VehicleManager.tsx
@@ -65,6 +65,10 @@ const VehicleManager: React.FC = () => {
   };
 
   const handleShare = async () => {
+    if ( !jwt || !redirectUri ) {
+        alert("Could not share vehicles, authentication failed");
+        return;
+    }
     const permissionsObject: SACD_PERMISSIONS = permissionTemplate?.data.scope
       .permissions
       ? permissionTemplate.data.scope.permissions.reduce(
@@ -94,7 +98,7 @@ const VehicleManager: React.FC = () => {
           }
         }
 
-        sendTokenToParent(jwt!, redirectUri!, () => {
+        sendTokenToParent(jwt, redirectUri, () => {
           //TODO: Better handling of null
           setSelectedVehicles([]); // Clear selection after sharing
           setAuthStep(3); // Move to success page

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -29,30 +29,31 @@ import { authenticateUser } from "../utils/authUtils";
 import { UserObject } from "../models/user";
 import { createPasskey } from "../services/turnkeyService";
 import { useDevCredentials } from "./DevCredentialsContext";
+import { CredentialResult, OtpResult, UserResult } from "../models/resultTypes";
 
 interface AuthContextProps {
   createAccountWithPasskey: (
     email: string
-  ) => Promise<{ success: boolean; user?: UserObject; error?: string }>;  
+  ) => Promise<UserResult>;
   sendOtp: (
     email: string
-  ) => Promise<{ success: boolean; otpId?: string; error?: string }>;
+  ) => Promise<OtpResult>;
   verifyOtp: (
     email: string,
     otp: string,
     otpId: string
-  ) => Promise<{ success: boolean; credentialBundle?: string; error?: string }>;
+  ) => Promise<CredentialResult>;
   authenticateUser: (
     email: string,
     credentialBundle: string,
     setJwt: (jwt: string) => void,
     setAuthStep: (step: number) => void
   ) => void;
-  user: UserObject | null;
-  setUser: React.Dispatch<React.SetStateAction<UserObject | null>>;
-  loading: boolean; // Add loading state to context
-  jwt: string | null;
-  setJwt: React.Dispatch<React.SetStateAction<string | null>>;
+  user: UserObject | undefined;
+  setUser: React.Dispatch<React.SetStateAction<UserObject | undefined>>;
+  loading: boolean | string; // Add loading state to context
+  jwt: string | undefined;
+  setJwt: React.Dispatch<React.SetStateAction<string | undefined>>;
   authStep: number;
   setAuthStep: React.Dispatch<React.SetStateAction<number>>;
 }
@@ -65,15 +66,26 @@ export const AuthProvider = ({
 }: {
   children: ReactNode;
 }): JSX.Element => {
-  const [loading, setLoading] = useState(false);
-  const [user, setUser] = useState<UserObject | null>(null);
-  const [jwt, setJwt] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean | string>(false);
+  const [user, setUser] = useState<UserObject | undefined>(undefined);
+  const [jwt, setJwt] = useState<string | undefined>(undefined);
   const [error, setError] = useState<string | null>(null);
   const [authStep, setAuthStep] = useState<number>(0); // 0 = Email Input, 1 = Loading, 2 = Success
   const { clientId, apiKey, redirectUri, permissionTemplateId } =
     useDevCredentials();
 
-  const createAccountWithPasskey = async (email: string) => {
+  const createAccountWithPasskey = async (
+    email: string
+  ): Promise<UserResult> => {
+    setLoading("Creating account");
+    setError(null);    
+    if (!apiKey) {
+      return {
+        success: false,
+        error: "API key is required for account creation",
+      };
+    }
+
     try {
       // Create passkey and get attestation
       const [attestation, challenge] = await createPasskey(email);
@@ -81,31 +93,41 @@ export const AuthProvider = ({
       // Trigger account creation request
       const account = await createAccount(
         email,
-        apiKey!,
+        apiKey,
         attestation as object,
         challenge as string,
         true
       ); //TODO: Better handling of types
-      if (account.success && account.user) {
-        setUser(account.user); // Store the user object in the context
-        return { success: true, user: account.user };
+      if (account.success && account.data.user) {
+        setUser(account.data.user); // Store the user object in the context
+        return { success: true, data: { user: account.data.user } };
       } else {
         throw new Error("Failed to create account");
       }
     } catch (error) {
       console.error("Account creation failed:", error);
-      return { success: false };
+      return { success: false, error: error as string };
+    } finally {
+      setLoading(false);
     }
   };
 
   const handleSendOtp = async (
     email: string
-  ): Promise<{ success: boolean; otpId?: string; error?: string }> => {
-    setLoading(true);
+  ): Promise<OtpResult> => {
+    setLoading("Sending OTP");
     setError(null);
+
+    if (!apiKey) {
+      return {
+        success: false,
+        error: "API key is to send an OTP",
+      };
+    }
+
     try {
       // Try sending OTP first
-      let otpResult = await sendOtp(email, apiKey!);
+      let otpResult = await sendOtp(email, apiKey);
       if (!otpResult.success) {
         // If sending OTP fails, attempt account creation and retry OTP
         const accountCreation = await createAccountWithPasskey(email);
@@ -113,17 +135,17 @@ export const AuthProvider = ({
           throw new Error("Account creation failed during OTP setup.");
 
         // Retry sending OTP after successful account creation
-        otpResult = await sendOtp(email, apiKey!);
+        otpResult = await sendOtp(email, apiKey);
         if (!otpResult.success)
           throw new Error("Failed to send OTP after account creation.");
       }
 
-      console.log(`OTP sent to ${email}, OTP ID: ${otpResult.otpId}`);
-      return { success: true, otpId: otpResult.otpId };
+      console.log(`OTP sent to ${email}, OTP ID: ${otpResult.data.otpId}`);
+      return { success: true, data: {otpId: otpResult.data.otpId} };
     } catch (err) {
       setError("Failed to send OTP");
       console.error(err);
-      return { success: false };
+      return { success: false, error: error as string };
     } finally {
       setLoading(false);
     }
@@ -133,25 +155,24 @@ export const AuthProvider = ({
     email: string,
     otp: string,
     otpId: string
-  ): Promise<{
-    success: boolean;
-    credentialBundle?: string;
-    error?: string;
-  }> => {
-    setLoading(true);
+  ): Promise<CredentialResult> => {
+    setLoading("Verifying OTP");
     setError(null);
     try {
       const result = await verifyOtp(email, otp, otpId);
-      if (result.success && result.credentialBundle) {
+      if (result.success && result.data.credentialBundle) {
         console.log(`OTP verified for ${email}`);
-        return { success: true, credentialBundle: result.credentialBundle };
+        return {
+          success: true,
+          data: {credentialBundle: result.data.credentialBundle},
+        };
       } else {
         throw new Error("Invalid OTP");
       }
     } catch (err) {
       setError("Failed to verify OTP");
       console.error(err);
-      return { success: false };
+      return { success: false, error: error as string };
     } finally {
       setLoading(false);
     }
@@ -163,7 +184,7 @@ export const AuthProvider = ({
     setJwt: (jwt: string) => void,
     setAuthStep: (step: number) => void
   ) => {
-    setLoading(true);
+    setLoading("Authenticating User");
     setError(null);
 
     try {
@@ -171,13 +192,17 @@ export const AuthProvider = ({
         throw new Error("No user found");
       }
 
+      if (!clientId || !redirectUri) {
+        throw new Error("Developer credentials not found");
+      }
+
       await authenticateUser(
         email,
-        clientId!,
-        redirectUri!,
+        clientId,
+        redirectUri,
         user.subOrganizationId,
         user.walletAddress,
-        user!.smartContractAddress!,
+        user.smartContractAddress,
         setJwt,
         setAuthStep,
         permissionTemplateId

--- a/src/models/resultTypes.ts
+++ b/src/models/resultTypes.ts
@@ -1,0 +1,14 @@
+// src/types/resultTypes.ts
+
+import { UserObject } from "./user";
+
+// Generalized Result Type
+export type Result<T> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+// Specific Result Types
+export type UserResult = Result<{ user: UserObject }>;
+export type OtpResult = Result<{ otpId: string }>;
+export type CredentialResult = Result<{ credentialBundle: string }>;
+export type SimpleResult = Result<null>;

--- a/src/services/accountsService.ts
+++ b/src/services/accountsService.ts
@@ -117,7 +117,7 @@ export const createAccount = async (
   attestation?: object,
   challenge?: string,
   deployAccount?: boolean,
-): Promise<{ success: boolean }> => {
+): Promise<{ success: boolean, user?: UserObject }> => {
   const response = await fetch(`${DIMO_ACCOUNTS_BASE_URL}/account`, {
     method: "POST",
     headers: {
@@ -135,7 +135,10 @@ export const createAccount = async (
   if (!response.ok) {
     throw new Error("Failed to create account");
   }
-  return { success: true };
+
+  const user = await response.json();
+
+  return { success: true, user: {...user, email} };
 };
 
 // Function to deploy an account

--- a/src/services/accountsService.ts
+++ b/src/services/accountsService.ts
@@ -6,13 +6,26 @@
  *
  */
 
+import {
+  CredentialResult,
+  OtpResult,
+  SimpleResult,
+  UserResult,
+} from "../models/resultTypes";
 import { UserObject } from "../models/user";
 import { generateTargetPublicKey } from "../utils/authUtils";
 
-const DIMO_ACCOUNTS_BASE_URL = process.env.REACT_APP_DIMO_ACCOUNTS_URL || 'https://accounts.dev.dimo.org/api';
+const DIMO_ACCOUNTS_BASE_URL =
+  process.env.REACT_APP_DIMO_ACCOUNTS_URL ||
+  "https://accounts.dev.dimo.org/api";
+
+type Result<T> = { success: true; data: T } | { success: false; error: string };
 
 // Example: Send OTP using Accounts API
-export const sendOtp = async (email: string, apiKey: string): Promise<{ success: boolean, otpId?: string; error?: string }> => {
+export const sendOtp = async (
+  email: string,
+  apiKey: string
+): Promise<OtpResult> => {
   // Call Turnkey's OTP generation API/SDK
   //Endpoint: POST /api/auth/otp
   const response = await fetch(`${DIMO_ACCOUNTS_BASE_URL}/auth/otp`, {
@@ -36,13 +49,13 @@ export const sendOtp = async (email: string, apiKey: string): Promise<{ success:
   }
 
   // Parse successful response
-  const data = await response.json();
-  if (!data.otpId) {
+  const responseData = await response.json();
+  if (!responseData.otpId) {
     throw new Error("OTP ID not found in response");
   }
 
   // Return success with OTP ID
-  return { success: true, otpId: data.otpId };
+  return { success: true, data: { otpId: responseData.otpId } };
 };
 
 // Example: Verify OTP using Accounts API
@@ -50,7 +63,7 @@ export const verifyOtp = async (
   email: string,
   otp: string,
   otpId: string
-): Promise<{success: boolean, credentialBundle?: string; error?: string}> => {
+): Promise<CredentialResult> => {
   // Call Turnkey's OTP verification API/SDK
   //Endpoint: PUT /api/auth/otp
   console.log(`Verifying OTP, Email:${email}, OTP: ${otp}, OtpID: ${otpId}`);
@@ -72,42 +85,48 @@ export const verifyOtp = async (
     throw new Error("Failed to send OTP");
   }
 
-//   // Parse successful response
-  const data = await response.json();
-  if (!data.credentialBundle) {
+  //   // Parse successful response
+  const responseData = await response.json();
+  if (!responseData.credentialBundle) {
     throw new Error("Could not retrieve credential bundle");
   }
 
-//   // Return success with OTP ID
-  return { success: true, credentialBundle: data.credentialBundle };
+  //   // Return success with OTP ID
+  return {
+    success: true,
+    data: { credentialBundle: responseData.credentialBundle },
+  };
 };
 
 export const verifyEmail = async (
   email: string,
   encodedChallenge: string,
-  attestation: object,
-): Promise<{success: boolean, credentialBundle?: string; error?: string}> => {
+  attestation: object
+): Promise<SimpleResult> => {
   // Call Turnkey's OTP verification API/SDK
   //Endpoint: PUT /api/auth/otp
-  const response = await fetch(`${DIMO_ACCOUNTS_BASE_URL}/account/verify-email`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      email,
-      encodedChallenge,
-      attestation,
-    }),
-  });
+  const response = await fetch(
+    `${DIMO_ACCOUNTS_BASE_URL}/account/verify-email`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        email,
+        encodedChallenge,
+        attestation,
+      }),
+    }
+  );
 
   // Handle response failure cases first
   if (!response.ok) {
     throw new Error("Failed to send OTP");
   }
 
-//   // Return success with OTP ID
-  return { success: true };
+  //   // Return success with OTP ID
+  return { success: true, data: null };
 };
 
 // Function to create an account
@@ -116,8 +135,8 @@ export const createAccount = async (
   apiKey: string,
   attestation?: object,
   challenge?: string,
-  deployAccount?: boolean,
-): Promise<{ success: boolean, user?: UserObject }> => {
+  deployAccount?: boolean
+): Promise<UserResult> => {
   const response = await fetch(`${DIMO_ACCOUNTS_BASE_URL}/account`, {
     method: "POST",
     headers: {
@@ -138,27 +157,27 @@ export const createAccount = async (
 
   const user = await response.json();
 
-  return { success: true, user: {...user, email} };
+  return { success: true, data: { user: { ...user, email } } };
 };
 
 // Function to deploy an account
-export const deployAccount = async (email: string): Promise<{ success: boolean }> => {
-    const response = await fetch(`${DIMO_ACCOUNTS_BASE_URL}/account/deploy`, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ email }),
-    });
+export const deployAccount = async (email: string): Promise<SimpleResult> => {
+  const response = await fetch(`${DIMO_ACCOUNTS_BASE_URL}/account/deploy`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ email }),
+  });
 
-    if (!response.ok) {
-        throw new Error('Failed to deploy account');
-    }
-    return { success: true };
+  if (!response.ok) {
+    throw new Error("Failed to deploy account");
+  }
+  return { success: true, data: null };
 };
 
 // src/services/authService.ts
-export const fetchUserDetails = async (email: string): Promise<{ success: boolean; error?: string; user?: UserObject }> => {
+export const fetchUserDetails = async (email: string): Promise<UserResult> => {
   try {
     const response = await fetch(`${DIMO_ACCOUNTS_BASE_URL}/account/${email}`, {
       method: "GET",
@@ -169,13 +188,19 @@ export const fetchUserDetails = async (email: string): Promise<{ success: boolea
 
     if (!response.ok) {
       const errorData = await response.json();
-      return { success: false, error: errorData.message || 'Failed to fetch user details' };
+      return {
+        success: false,
+        error: errorData.message || "Failed to fetch user details",
+      };
     }
 
     const user = await response.json();
-    return { success: true, user: {...user, email} };
+    return { success: true, data: { user: { ...user, email } } };
   } catch (error) {
-    console.error('Error fetching user details:', error);
-    return { success: false, error: 'An error occurred while fetching user details' };
+    console.error("Error fetching user details:", error);
+    return {
+      success: false,
+      error: "An error occurred while fetching user details",
+    };
   }
 };

--- a/src/services/turnkeyService.ts
+++ b/src/services/turnkeyService.ts
@@ -93,8 +93,6 @@ export const openSessionWithPasskey = async () => {
 
 export const signChallenge = async (
   challenge: string,
-  organizationId: string,
-  walletAddress: string
 ) => {
 
   //This is triggering a turnkey API request to sign a raw payload 

--- a/src/utils/authUtils.ts
+++ b/src/utils/authUtils.ts
@@ -96,12 +96,16 @@ export async function authenticateUser(
   redirectUri: string,
   subOrganizationId: string | null,
   walletAddress: string | null,
-  smartContractAddress: string,
+  smartContractAddress: string | null,
   setJwt: (jwt: string) => void,
   setAuthStep: (step: number) => void,
   permissionTemplateId?: string
 ) {
   console.log(`Authenticating user with email: ${email}`);
+
+  if ( !smartContractAddress ) {
+    throw new Error("Could not authenticate user, account not deployed");
+  }
 
 
   if (subOrganizationId && walletAddress) {
@@ -120,9 +124,7 @@ export async function authenticateUser(
       const state = resp.data.state;
 
       const signature = await signChallenge(
-        challenge,
-        subOrganizationId,
-        walletAddress
+        challenge
       );
 
       if (signature) {


### PR DESCRIPTION
Previously
- Login: Fetch User Details -> Authenticate User (also calls fetch user details)
- Signup: Send Otp -> Account Creation (which then retriggers send otp)

Now
- Login: Fetch User Details (sets user) -> Authenticate User (no extra fetch call)
- Signup: Account Creation -> Send Otp


Changes
- New Auth Context functions (setUser, createAccountWithPasskey)
- createAccount now returns user, to allow setting
- On Email submit, user is set after fetching user details