### PR TITLE
Dec 4th UI Cleanup

### DIFF
--- a/src/components/AdvancedTransaction/AdvancedTransaction.tsx
+++ b/src/components/AdvancedTransaction/AdvancedTransaction.tsx
@@ -18,8 +18,7 @@ import { sendMessageToReferrer } from "../../utils/messageHandler";
 const AdvancedTransaction: React.FC = () => {
   //TODO
   //Loading and Error Handling should not be determined by AuthContext
-  const { redirectUri, setUiState, setComponentData } =
-    useDevCredentials();
+  const { redirectUri, setUiState, setComponentData } = useDevCredentials();
   const { user, setLoading, setError, error } = useAuthContext();
 
   const [transactionData, setTransactionData] = useState<
@@ -98,7 +97,9 @@ const AdvancedTransaction: React.FC = () => {
   };
 
   const onReject = async () => {
-    //TBD
+    //This will send the message, and close the winodw
+    //Doesn't currently handle redirecting
+    sendErrorToParent(`User Rejected the Transaction`, redirectUri!);
   };
 
   return (

--- a/src/components/AdvancedTransaction/SuccessfulTransaction.tsx
+++ b/src/components/AdvancedTransaction/SuccessfulTransaction.tsx
@@ -5,9 +5,10 @@ import Header from "../Shared/Header";
 import PrimaryButton from "../Shared/PrimaryButton";
 import { useDevCredentials } from "../../context/DevCredentialsContext";
 import ErrorScreen from "../Shared/ErrorScreen";
+import { isStandalone } from "../../utils/isStandalone";
 
 const SuccessfulTransaction: React.FC = () => {
-  const { componentData } = useDevCredentials();
+  const { componentData, redirectUri, devLicenseAlias } = useDevCredentials();
 
   if (!componentData.transactionHash) {
     return (
@@ -29,10 +30,23 @@ const SuccessfulTransaction: React.FC = () => {
     }
   };
 
+  const handleBackToThirdParty = () => {
+    if ( window.opener ) {
+      //Popup Mode
+      window.close();
+    } else if (isStandalone()) {
+      //Redirect Mode
+      window.location.href = `${redirectUri}`
+    }
+  };  
+
   return (
     <Card width="w-full max-w-[600px]" height="h-full max-h-[308px]">
       <Header title="Successful Transaction!" subtitle={""} />
       <div className="flex justify-center">
+        <PrimaryButton onClick={handleBackToThirdParty} width="max-w-[440px]">
+          Back to {devLicenseAlias}
+        </PrimaryButton>        
         <PrimaryButton onClick={handleView} width="w-[214px]">
           View Transaction
         </PrimaryButton>

--- a/src/components/Auth/SuccessPage.tsx
+++ b/src/components/Auth/SuccessPage.tsx
@@ -9,7 +9,7 @@ import { buildAuthPayload, sendAuthPayloadToParent } from "../../utils/authUtils
 
 const SuccessPage: React.FC = () => {
   const { user, jwt } = useAuthContext(); // Should be set on session init
-  const { redirectUri, setUiState, clientId } = useDevCredentials();
+  const { redirectUri, setUiState, clientId, devLicenseAlias } = useDevCredentials();
 
   const sendJwtAfterPermissions = () => {
     if (jwt && redirectUri && clientId) {
@@ -28,7 +28,7 @@ const SuccessPage: React.FC = () => {
       <Header title="You are logged in!" subtitle={user ? user.email : ""} />
       <div className="flex justify-center">
         <PrimaryButton onClick={handleContinue} width="w-[214px]">
-          Continue
+          Back to {devLicenseAlias}
         </PrimaryButton>
       </div>
     </Card>

--- a/src/components/Vehicles/VehicleManager.tsx
+++ b/src/components/Vehicles/VehicleManager.tsx
@@ -314,7 +314,7 @@ const VehicleManager: React.FC = () => {
               All vehicles have been shared
             </h2>
             <p className="text-sm">
-              You have already shared all your vehicles.
+              You have already shared all your vehicles with {devLicenseAlias}.
             </p>
           </div>
         )}

--- a/src/utils/errorUtils.ts
+++ b/src/utils/errorUtils.ts
@@ -14,5 +14,10 @@ export function sendErrorToParent(error: Error | string, redirectUri: string) {
   // Send error details to parent via postMessage
   sendMessageToReferrer({eventType:"DIMO_ERROR", message: errorMessage});
 
+  if (window.opener) {
+    //Close popup window after auth
+    window.close();
+  }  
+
   // Trigger error callback
 }

--- a/src/utils/txnUtils.ts
+++ b/src/utils/txnUtils.ts
@@ -18,6 +18,11 @@ export function sendTxnResponseToParent(
     transactionHash,
   });
 
+  if (window.opener) {
+    //Close popup window after auth
+    window.close();
+  }  
+
   onSuccess(transactionHash);
 
   // Trigger success callback


### PR DESCRIPTION
Updates
- Transaction on Reject, now sends error message to developer (user rejected), and closes the popup/redirects
- Successful transaction screen, now shoes a button to go back to 3rd party, which redirect/closes popup
- You are logged in screen, now shows a button to go back to 3rd party, which closes/redirects
- Shared vehicles screen now shows the dev license alias that vehicles have been shared with