### PR TITLE
[LIWD] Animate the transactions screens

### DIFF
--- a/src/components/AdvancedTransaction/AdvancedTransaction.tsx
+++ b/src/components/AdvancedTransaction/AdvancedTransaction.tsx
@@ -64,7 +64,7 @@ const AdvancedTransaction: React.FC = () => {
   }
 
   const onApprove = async () => {
-    setLoadingState(true, "Executing Transaction");
+    setLoadingState(true, "Executing Transaction", true);
     //Ensure Passkey
 
     await initializeIfNeeded(user.subOrganizationId);

--- a/src/components/Vehicles/ManageVehicle.tsx
+++ b/src/components/Vehicles/ManageVehicle.tsx
@@ -34,7 +34,7 @@ const ManageVehicle: React.FC = () => {
       actionType === "revoke" ? "Revoking vehicles" : "Extending vehicles";
     const newAction = actionType === "revoke" ? "revoked" : "extended";
 
-    setLoadingState(true, loadingMessage);
+    setLoadingState(true, loadingMessage, true);
 
     await initializeIfNeeded(user.subOrganizationId);
 

--- a/src/components/Vehicles/SelectVehicles.tsx
+++ b/src/components/Vehicles/SelectVehicles.tsx
@@ -123,7 +123,7 @@ const SelectVehicles: React.FC<SelectVehiclesProps> = ({
   };
 
   const handleShare = async () => {
-    setLoadingState(true, "Sharing vehicles");
+    setLoadingState(true, "Sharing vehicles", true);
 
     await initializeIfNeeded(user.subOrganizationId);
 

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -74,7 +74,7 @@ export const AuthProvider = ({
   const createAccountWithPasskey = async (
     email: string
   ): Promise<UserResult> => {
-    setLoadingState(true, "Creating account");
+    setLoadingState(true, "Creating account", true);
     setError(null);
     if (!apiKey) {
       return {
@@ -114,7 +114,7 @@ export const AuthProvider = ({
   };
 
   const handleSendOtp = async (email: string): Promise<OtpResult> => {
-    setLoadingState(true, "Sending OTP");
+    setLoadingState(true, "Sending OTP", true);
     setError(null);
 
     if (!apiKey) {
@@ -155,7 +155,7 @@ export const AuthProvider = ({
     email: string,
     otp: string
   ): Promise<CredentialResult> => {
-    setLoadingState(true, "Verifying OTP");
+    setLoadingState(true, "Verifying OTP", true);
     setError(null);
     try {
       const result = await verifyOtp(email, otp, otpId);

--- a/src/context/UIManagerContext.tsx
+++ b/src/context/UIManagerContext.tsx
@@ -1,5 +1,7 @@
 import React, { createContext, ReactNode, useContext, useState } from "react";
 
+import useLoading from "../hooks/useLoading";
+
 interface UiStateOptionProps {
   setBack: boolean;
   removeCurrent?: boolean;
@@ -16,7 +18,11 @@ interface UIManagerContextProps {
   setComponentData: React.Dispatch<React.SetStateAction<any>>;
   isLoading: boolean;
   loadingMessage: string;
-  setLoadingState: (loading: boolean, message?: string) => void;
+  setLoadingState: (
+    loading: boolean,
+    message?: string,
+    isLongProcess?: boolean
+  ) => void;
   error: string | null;
   setError: React.Dispatch<React.SetStateAction<string | null>>;
 }
@@ -44,14 +50,8 @@ export const UIManagerProvider = ({ children }: { children: ReactNode }) => {
   const [prevUiStates, setPrevUiStates] = useState<UiStates[]>([]);
   const [entryState, setEntryState] = useState<UiStates>(UiStates.EMAIL_INPUT);
   const [componentData, setComponentData] = useState<any | null>(null); // Initial component data
-  const [isLoading, setIsLoading] = useState(false);
-  const [loadingMessage, setLoadingMessage] = useState("");
+  const [isLoading, setLoadingState, loadingMessage] = useLoading(false);
   const [error, setError] = useState<string | null>(null);
-
-  const setLoadingState = (loading: boolean, message: string = "") => {
-    setIsLoading(loading);
-    setLoadingMessage(loading ? message : ""); // Clear the message if not loading
-  };
 
   const handleUiState = (
     value: UiStates,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from "./useLoading";

--- a/src/hooks/useLoading.ts
+++ b/src/hooks/useLoading.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+
+const useLoading = (
+  initialLoadingState: boolean
+): [boolean, (loading: boolean, message?: string) => void, string] => {
+  const [isLoading, setIsLoading] = useState(initialLoadingState);
+  const [isLongProcess, setIsLongProcess] = useState<boolean>(false);
+  const [message, setMessage] = useState<string>("");
+
+  const handleSetLoading = (
+    loading: boolean,
+    message?: string,
+    isLongProcess?: boolean
+  ) => {
+    setIsLoading(loading);
+    setIsLongProcess(isLongProcess || false);
+    setMessage(loading && message ? message : "");
+  };
+
+  useEffect(() => {
+    if (!isLongProcess) return;
+
+    let timeoutIdStillWorking: NodeJS.Timeout | null = null;
+    let timeoutIdAlmostThere: NodeJS.Timeout | null = null;
+
+    if (isLoading) {
+      timeoutIdStillWorking = setTimeout(() => {
+        setMessage("Still working…");
+      }, 5000);
+
+      timeoutIdAlmostThere = setTimeout(() => {
+        setMessage("Hang tight, almost there.");
+      }, 8000);
+    }
+
+    return () => {
+      if (timeoutIdStillWorking) clearTimeout(timeoutIdStillWorking);
+      if (timeoutIdAlmostThere) clearTimeout(timeoutIdAlmostThere);
+    };
+  }, [isLoading, isLongProcess]);
+
+  return [isLoading, handleSetLoading, message];
+};
+
+export default useLoading;

--- a/src/hooks/useLoading.ts
+++ b/src/hooks/useLoading.ts
@@ -29,7 +29,7 @@ const useLoading = (
       }, 5000);
 
       timeoutIdAlmostThere = setTimeout(() => {
-        setMessage("Hang tight, almost there.");
+        setMessage("Hang tight, almost there");
       }, 8000);
     }
 


### PR DESCRIPTION
### Changes
---
Right now the sharing vehicle waiting screen shows Sharing Vehicles and it may take longer than 10 seconds to complete. 

The task is to break this waiting screen up into 3 parts, the break between the 3 doesn't really matter that much as the idea is to show progress:

- 0~5 seconds (Fetching your vehicles)
- 5+ seconds (Still working…)
- 8+ seconds (Hang tight, almost there)

Similarly for Advanced Transactions, Executing transactions should also be broken up into parts:

- Executing transactions
- Still working…
- Hang tight, almost there