### PR TITLE
DVR-641: config cid swap, attachment link, attach contract to sacd

### DIFF
--- a/src/enums/config.ts
+++ b/src/enums/config.ts
@@ -14,6 +14,9 @@ export enum HEADERS {
  * where the CIDs could be fetched or configured dynamically instead of being hardcoded.
  */
 export enum POLICY_ATTACHMENT_CID_BY_REGION {
-  US = 'bafybeihgtdpgnjj3tupbnzat5epidn2hzpvhexmcq24hlukizd4xlgopau',
-  EU = 'bafybeidvnxcdrtbb2y4kj5h3wuxzrah4tbazfeob3hnclzdwtvi6htikgu',
+  // BARRETT TODO: Revert back after DEMO
+  // US = 'bafybeihgtdpgnjj3tupbnzat5epidn2hzpvhexmcq24hlukizd4xlgopau',
+  // EU = 'bafybeidvnxcdrtbb2y4kj5h3wuxzrah4tbazfeob3hnclzdwtvi6htikgu',
+  US = 'QmPP5QCh662B4nW8nUcJLby7NKXuKy61mKwUmvXhxTrW6B',
+  EU = 'QmPzPkwyrHHQbgxcbvBACiy6PRdpKbVUHbZibAxVAsVdQg'
 }

--- a/src/services/permissionsService.ts
+++ b/src/services/permissionsService.ts
@@ -81,6 +81,8 @@ export const fetchPermissionsFromId = async ({
       : '';
   console.log('contractAttachmentLink', contractAttachmentLink);
   console.log('region', region);
+  const urlMatch = contractAttachmentLink.match(/href="([^"]*)"/);
+  const extractedAttachmentUrl = urlMatch ? urlMatch[1] : '';
 
   const description = `This contract gives permission for specific data access and control functions on the DIMO platform. Here’s what you’re agreeing to:\n\nContract Summary:\n- Grantor: ${email} (the entity giving permission).\n- Grantee: ${devLicenseAlias}  (the entity receiving permission).\n\n${contractAttachmentLink}\n\nPermissions Granted:${permissionsString}\n\nEffective Date: ${formatBigIntAsReadableDate(
     currentTimeBigInt,
@@ -104,10 +106,9 @@ export const fetchPermissionsFromId = async ({
       },
       effectiveAt: currentTime.toISOString(),
       expiresAt: new Date(Number(expirationDate) * 1000).toISOString(),
-      attachments: [contractAttachmentLink],
+      attachments: extractedAttachmentUrl ? [extractedAttachmentUrl] : [],
       description,
     },
   };
-
   return template;
 };

--- a/src/services/permissionsService.ts
+++ b/src/services/permissionsService.ts
@@ -45,7 +45,9 @@ export const getContractAttachmentLink = (
   if (!cid) {
     return '';
   }
-  return `<a href="https://${cid}.ipfs.w3s.link/agreement-${region.toLowerCase()}.pdf" target="_blank">Contract Attachment</a>`;
+  // BARRETT TODO: Revert back after DEMO
+  // return `<a href="https://${cid}.ipfs.w3s.link/agreement-${region.toLowerCase()}.pdf" target="_blank">Contract Attachment</a>`;
+  return `<a href="https://assets.dimo.org/ipfs/${cid}" target="_blank">Contract Attachment</a>`
 };
 
 export const fetchPermissionsFromId = async ({
@@ -102,7 +104,7 @@ export const fetchPermissionsFromId = async ({
       },
       effectiveAt: currentTime.toISOString(),
       expiresAt: new Date(Number(expirationDate) * 1000).toISOString(),
-      attachments: [],
+      attachments: [contractAttachmentLink],
       description,
     },
   };


### PR DESCRIPTION
For the purposes of OEM Demo, this update:

- temporarily updates config.ts with CIDs pointing to sample OEM privacy docs 
- updates permissionService.ts to point directly to assets.dimo.org/ipfs/${cid}
- ^ If this contract exists, it is attached to the SACD doc 