### PR TITLE
feat: include tokenDID with vehilce information from identity-api

### DIFF
--- a/src/models/__tests__/vehicle.test.ts
+++ b/src/models/__tests__/vehicle.test.ts
@@ -9,6 +9,7 @@ jest.mock('@dimo-network/transactions', () => ({
 describe('LocalVehicle', () => {
   const mockVehicleNode = {
     tokenId: 123,
+    tokenDID: 'did:erc721:0xbA5738a18d83D41847dfFbDC6101d37C69c9B0cF:123',
     imageURI: 'http://image.url',
     definition: {
       id: 'mock_def_id',
@@ -49,6 +50,7 @@ describe('LocalVehicle', () => {
   it('normalizes vehicle data', () => {
     expect(localVehicle.normalize()).toEqual({
       tokenId: 123,
+      tokenDID: 'did:erc721:0xbA5738a18d83D41847dfFbDC6101d37C69c9B0cF:123',
       imageURI: 'http://image.url',
       make: 'Tesla',
       model: 'Model S',

--- a/src/models/vehicle.ts
+++ b/src/models/vehicle.ts
@@ -2,6 +2,7 @@ import { fetchDeviceDefinition, VehicleNode } from '../services';
 
 export interface Vehicle {
   tokenId: number;
+  tokenDID: string;
   imageURI: string;
   make: string;
   model: string;
@@ -64,6 +65,7 @@ export class LocalVehicle {
   normalize() {
     return {
       tokenId: this.tokenId,
+      tokenDID: this.vehicleNode.tokenDID,
       imageURI: this.vehicleNode.imageURI,
       make: this.make,
       model: this.model,

--- a/src/services/__tests__/vehicleService.test.ts
+++ b/src/services/__tests__/vehicleService.test.ts
@@ -21,6 +21,7 @@ beforeEach(() => {
           nodes: [
             {
               tokenId: 1,
+              tokenDID: 'did:erc721:0xbA5738a18d83D41847dfFbDC6101d37C69c9B0cF:1',
               imageURI: 'http://image.url',
               definition: {
                 id: 'tesla_model_3_2019',
@@ -34,6 +35,7 @@ beforeEach(() => {
             },
             {
               tokenId: 2,
+              tokenDID: 'did:erc721:0xbA5738a18d83D41847dfFbDC6101d37C69c9B0cF:2',
               imageURI: 'http://image.url',
               definition: {
                 id: 'ford_bronco_2023',
@@ -177,6 +179,7 @@ it('Returns vehicles with the correct shape in compatible and incompatible array
     expect(vehicle).toEqual(
       expect.objectContaining({
         tokenId: expect.any(Number),
+        tokenDID: expect.any(String),
         imageURI: expect.anything(),
         shared: expect.any(Boolean),
         expiresAt: expect.any(String),
@@ -201,6 +204,7 @@ it('Returns incompatible vehicles with the correct shape when no compatible vehi
     expect(vehicle).toEqual(
       expect.objectContaining({
         tokenId: expect.any(Number),
+        tokenDID: expect.any(String),
         imageURI: expect.anything(),
         shared: expect.any(Boolean),
         expiresAt: expect.any(String),

--- a/src/services/identityService.ts
+++ b/src/services/identityService.ts
@@ -35,6 +35,7 @@ const GET_VEHICLES = gql`
     ) {
       nodes {
         tokenId
+        tokenDID
         imageURI
         definition {
           id
@@ -61,6 +62,7 @@ const GET_VEHICLES = gql`
 
 export type VehicleNode = {
   tokenId: number;
+  tokenDID: string;
   imageURI: string;
   definition: {
     id: string;


### PR DESCRIPTION
Adding tokenDID to returned vehicle objects for devs.

Not sure this is PR is helpful or not so feel free to close it or merge at your own discretion.