### PR TITLE
feature: pre shared permissions

### DIFF
--- a/src/components/Vehicles/ManageVehicleDetails.tsx
+++ b/src/components/Vehicles/ManageVehicleDetails.tsx
@@ -1,14 +1,34 @@
-import { Vehicle } from '../../models/vehicle';
-import Header from '../Shared/Header';
 import React from 'react';
 
+import { Vehicle } from '../../models/vehicle';
+import Header from '../Shared/Header';
+import { SharedPermissionsNote } from './';
+import { useDevCredentials } from '../../context/DevCredentialsContext';
+import { VehicleManagerMandatoryParams } from '../../types';
+import { hasUpdatedPermissions } from '../../utils/permissions';
+
 export const ManageVehicleDetails = ({ vehicle }: { vehicle: Vehicle }) => {
+  const { permissions, permissionTemplateId } =
+    useDevCredentials<VehicleManagerMandatoryParams>();
+
+  const {
+    tokenId,
+    shared,
+    expiresAt,
+    make,
+    model,
+    year,
+    permissions: vehiclePermissions,
+  } = vehicle;
+  const hasUpdatedPerms = hasUpdatedPermissions(
+    vehiclePermissions,
+    permissions,
+    permissionTemplateId,
+  );
+
   return (
     <>
-      <Header
-        title={`${vehicle.make} ${vehicle.model} ${vehicle.year}`}
-        subtitle={`ID:${vehicle.tokenId}`}
-      />
+      <Header title={`${make} ${model} ${year}`} subtitle={`ID:${tokenId}`} />
 
       <img
         style={{ height: '80px', width: '80px' }}
@@ -16,10 +36,12 @@ export const ManageVehicleDetails = ({ vehicle }: { vehicle: Vehicle }) => {
         src={
           'https://assets.dimo.xyz/ipfs/QmaaxazmGtNM6srcRmLyNdjCp8EAmvaTDYSo1k2CXVRTaY'
         }
-        alt={`${vehicle.make} ${vehicle.model}`}
+        alt={`${make} ${model}`}
       />
 
-      <p className="text-center mt-8">Shared until {vehicle.expiresAt}</p>
+      <p className="text-center mt-8">Shared until {expiresAt}</p>
+
+      <SharedPermissionsNote shared={shared} hasUpdatedPermissions={hasUpdatedPerms} />
     </>
   );
 };

--- a/src/components/Vehicles/SharedPermissionsNote.tsx
+++ b/src/components/Vehicles/SharedPermissionsNote.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+interface SharedPermissionsNoteProps {
+  shared: boolean;
+  hasUpdatedPermissions: boolean;
+}
+
+export const SharedPermissionsNote: React.FC<SharedPermissionsNoteProps> = ({
+  shared,
+  hasUpdatedPermissions,
+}) => {
+  if (!shared || hasUpdatedPermissions) {
+    return null;
+  }
+
+  return (
+    <p className="text-xs text-gray-500 mt-2">
+      <span className="font-semibold">Note:</span> Shared with old permissions, to update
+      it stop sharing and re-share
+    </p>
+  );
+};

--- a/src/components/Vehicles/VehicleCard.tsx
+++ b/src/components/Vehicles/VehicleCard.tsx
@@ -4,6 +4,10 @@ import { Vehicle } from '../../models/vehicle';
 import { UiStates } from '../../enums';
 import { useUIManager } from '../../context/UIManagerContext';
 import { Checkbox } from '../Shared/Checkbox';
+import { useDevCredentials } from '../../context/DevCredentialsContext';
+import { VehicleManagerMandatoryParams } from '../../types';
+import { SharedPermissionsNote } from './';
+import { hasUpdatedPermissions } from '../../utils/permissions';
 
 interface VehicleCardProps {
   vehicle: Vehicle;
@@ -20,7 +24,24 @@ export const VehicleCard: React.FC<VehicleCardProps> = ({
   disabled,
   incompatible,
 }) => {
-  const { componentData, setComponentData, setUiState } = useUIManager(); // Access the manage function from the context
+  const { componentData, setComponentData, setUiState } = useUIManager();
+  const { permissions, permissionTemplateId } =
+    useDevCredentials<VehicleManagerMandatoryParams>();
+
+  const {
+    tokenId,
+    shared,
+    model,
+    make,
+    year,
+    expiresAt,
+    permissions: vehiclePermissions,
+  } = vehicle;
+  const hasUpdatedPerms = hasUpdatedPermissions(
+    vehiclePermissions,
+    permissions,
+    permissionTemplateId,
+  );
 
   const handleManageClick = (e: React.MouseEvent) => {
     setComponentData({ ...componentData, vehicle }); //Retains permissionTemplateID for Manage Vehicle
@@ -34,7 +55,7 @@ export const VehicleCard: React.FC<VehicleCardProps> = ({
       className={`flex items-center p-4 ${
         !disabled && 'border'
       } rounded-2xl cursor-pointer transition ${
-        vehicle.shared || incompatible
+        shared || incompatible
           ? 'bg-gray-100 text-gray-500 cursor-not-allowed'
           : 'hover:bg-gray-50 cursor-pointer'
       } ${isSelected && 'border-black'}`}
@@ -42,12 +63,12 @@ export const VehicleCard: React.FC<VehicleCardProps> = ({
       {/* Custom Checkbox */}
       {!disabled && !incompatible && (
         <Checkbox
-          checked={isSelected || vehicle.shared}
+          checked={isSelected || shared}
           onChange={onSelect}
-          id={`vehicle-${vehicle.tokenId.toString()}`}
-          name={`vehicle-${vehicle.tokenId.toString()}`}
+          id={`vehicle-${tokenId.toString()}`}
+          name={`vehicle-${tokenId.toString()}`}
           className="mr-4 w-5 h-5 text-black border-gray-300 rounded focus:ring-0 focus:ring-offset-0 accent-black cursor-pointer"
-          disabled={vehicle.shared}
+          disabled={shared}
         />
       )}
 
@@ -55,8 +76,8 @@ export const VehicleCard: React.FC<VehicleCardProps> = ({
         <Checkbox
           checked={true}
           onChange={onSelect}
-          id={`vehicle-${vehicle.tokenId.toString()}`}
-          name={`vehicle-${vehicle.tokenId.toString()}`}
+          id={`vehicle-${tokenId.toString()}`}
+          name={`vehicle-${tokenId.toString()}`}
           className="mr-4 w-5 h-5 border-gray-300 rounded appearance-none cursor-pointer bg-[#3C3C432E] text-white before:content-['X'] before:text-center before:text-white before:block disabled:cursor-not-allowed disabled:opacity-50"
           disabled={true}
         />
@@ -68,30 +89,28 @@ export const VehicleCard: React.FC<VehicleCardProps> = ({
         src={
           'https://assets.dimo.xyz/ipfs/QmaaxazmGtNM6srcRmLyNdjCp8EAmvaTDYSo1k2CXVRTaY'
         }
-        alt={`${vehicle.make} ${vehicle.model}`}
+        alt={`${make} ${model}`}
       />
 
       {/* Vehicle Information */}
       <label
-        htmlFor={`vehicle-${vehicle.tokenId.toString()}`}
+        htmlFor={`vehicle-${tokenId.toString()}`}
         className="flex-grow text-left hover:cursor-pointer"
       >
         <div className="text-black font-medium">
-          {vehicle.make} {vehicle.model} ({vehicle.year})
+          {make} {model} ({year})
         </div>
-        <div className="text-sm text-gray-500 font-medium">
-          ID: {vehicle.tokenId.toString()}
-        </div>
-        {vehicle.shared && (
-          <div className="text-sm text-gray-500">Shared Until: {vehicle.expiresAt}</div>
-        )}
+        <div className="text-sm text-gray-500 font-medium">ID: {tokenId.toString()}</div>
+        {shared && <div className="text-sm text-gray-500">Shared Until: {expiresAt}</div>}
+
+        <SharedPermissionsNote shared={shared} hasUpdatedPermissions={hasUpdatedPerms} />
       </label>
 
       {/* Manage Vehicle */}
-      {vehicle.shared && (
+      {shared && (
         <div
           onClick={handleManageClick}
-          className="flex justify-center items-center w-6 h-6 border border-gray-300 rounded-full cursor-pointer hover:border-gray-400 hover:bg-gray-100 hover:scale-105 transition duration-200"
+          className="flex justify-center items-center w-6 h-6 border border-gray-300 rounded-full cursor-pointer hover:border-gray-400 hover:bg-gray-100 hover:scale-105 transition duration-200 px-2"
         >
           <span className="text-black font-semibold text-xs mt-[-5px]">...</span>
         </div>

--- a/src/components/Vehicles/index.ts
+++ b/src/components/Vehicles/index.ts
@@ -4,6 +4,7 @@ export * from './EmptyState';
 export * from './ManageVehicle';
 export * from './MintVehicle';
 export * from './SelectVehicles';
+export * from './SharedPermissionsNote';
 export * from './SuccessfulPermissions';
 export * from './VehicleCard';
 export * from './VehicleManager';

--- a/src/models/vehicle.ts
+++ b/src/models/vehicle.ts
@@ -10,6 +10,7 @@ export interface Vehicle {
   year: number;
   shared: boolean;
   expiresAt: string;
+  permissions: bigint;
 }
 
 export interface VehicleResponse {

--- a/src/services/identityService.ts
+++ b/src/services/identityService.ts
@@ -46,6 +46,7 @@ const GET_VEHICLES = gql`
           nodes {
             expiresAt
             grantee
+            permissions
           }
         }
       }
@@ -71,6 +72,7 @@ export type VehicleNode = {
   sacds: {
     nodes: {
       expiresAt: string;
+      permissions: bigint;
       grantee: string;
     }[];
   };

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,0 +1,14 @@
+import { getPermissionsValue } from '@dimo-network/transactions';
+import { createPermissionsFromParams } from '../services/permissionsService';
+
+export const hasUpdatedPermissions = (
+  vehiclePermissions: bigint,
+  permissions: string,
+  permissionTemplateId?: string,
+) => {
+  const permsValue = getPermissionsValue(
+    createPermissionsFromParams(permissions, permissionTemplateId),
+  );
+
+  return vehiclePermissions === permsValue;
+};

--- a/src/utils/vehicles.ts
+++ b/src/utils/vehicles.ts
@@ -9,6 +9,7 @@ const transformVehicle = (
   const sacd = vehicle.getSacdForGrantee(grantee);
   return {
     ...vehicle.normalize(),
+    permissions: sacd ? sacd.permissions : BigInt(0),
     shared: !!sacd,
     expiresAt: sacd ? formatDate(sacd.expiresAt) : '',
   };


### PR DESCRIPTION
### Changes
---
Right now, when a vehicle was already shared before with a developer for a set of permissions (for example 1,2,3,4) but access the LIWD link again when it asks for 1,2,3,4,5,6,7,8 — since the vehicle was pre-shared, LIWD does not update the vehicle with the new SACD.

So when users are logged in with a pre-shared vehicle, check to see if the current requested permissions match with the existing SACD permissions. For the vehicles that have a different shared permissions compared to what was requested, flag it so that the user know

### Screenshots
---
<img width="604" height="754" alt="image" src="https://github.com/user-attachments/assets/0e703983-90b8-4eef-8c8d-e97330a68888" />
<img width="610" height="446" alt="image" src="https://github.com/user-attachments/assets/447403a9-52d8-40af-8029-9652deb55118" />
