### PR TITLE
fix(security): allowlist inbound AUTH_INIT postMessage params

### DIFF
--- a/src/context/DevCredentialsContext.tsx
+++ b/src/context/DevCredentialsContext.tsx
@@ -32,6 +32,7 @@ import { getDefaultExpirationDate } from '../utils/dateUtils';
 import { sendMessageToReferrer } from '../utils/messageHandler';
 import { isStandalone } from '../utils/isStandalone';
 import { getConfigurationById } from '../services/configurationService';
+import { filterMessageParams } from '../utils/messageParams';
 
 const DEFAULT_CONTEXT: AllParams = {
   clientId: null,
@@ -152,8 +153,12 @@ export const DevCredentialsProvider = ({
       customParams.waitingForParams = false;
     }
 
+    // Allowlist the inbound payload: a postMessage can come from any window, so
+    // only keys the app legitimately acts on are written to state. Internal
+    // control flags (waitingForDevLicense, invalidCredentials, oemBrand, …) and
+    // unknown keys are dropped. customParams is app-computed, not from the wire.
     applyDevCredentialsConfig({
-      ...sourceParams,
+      ...filterMessageParams(sourceParams),
       ...customParams,
     });
   };

--- a/src/context/__tests__/DevCredentialsContext.test.tsx
+++ b/src/context/__tests__/DevCredentialsContext.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { render, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 
-import { DevCredentialsProvider } from '../DevCredentialsContext';
+import { DevCredentialsProvider, useDevCredentials } from '../DevCredentialsContext';
 import { UIManagerProvider } from '../UIManagerContext';
 import { GlobalOraclesProvider } from '../OraclesContext';
 import { fetchOemBrand } from '../../services/brandService';
@@ -36,12 +36,21 @@ jest.mock('../../hooks', () => ({
 const CLIENT_ID = '0xb92d74B468B4047289AEa7c9B953066E39768C16';
 const fetchOemBrandMock = fetchOemBrand as jest.Mock;
 
-const renderProvider = () =>
+// Surfaces a single state key so tests can assert what did (and didn't) land in
+// devCredentialsState after a postMessage.
+const StateProbe = ({ probeKey }: { probeKey: string }) => {
+  const value = useDevCredentials<Record<string, unknown>>();
+  return (
+    <span data-testid="probe">{JSON.stringify(value[probeKey] ?? null)}</span>
+  );
+};
+
+const renderProvider = (probeKey = 'clientId') =>
   render(
     <UIManagerProvider>
       <GlobalOraclesProvider>
         <DevCredentialsProvider>
-          <div data-testid="child" />
+          <StateProbe probeKey={probeKey} />
         </DevCredentialsProvider>
       </GlobalOraclesProvider>
     </UIManagerProvider>,
@@ -102,5 +111,14 @@ describe('DevCredentialsContext brand forwarding', () => {
         'SomeOtherLicenseBrand',
       ),
     );
+  });
+
+  it('popup: drops a non-allowlisted key from the AUTH_INIT payload', async () => {
+    renderProvider('injectedKey');
+    await dispatchAuthInit({ clientId: CLIENT_ID, injectedKey: 'pwn' });
+
+    // wait until the message has been processed (clientId drives the brand fetch)
+    await waitFor(() => expect(fetchOemBrandMock).toHaveBeenCalled());
+    expect(screen.getByTestId('probe').textContent).toBe('null');
   });
 });

--- a/src/utils/__tests__/messageParams.test.ts
+++ b/src/utils/__tests__/messageParams.test.ts
@@ -1,0 +1,59 @@
+import { filterMessageParams, ALLOWED_MESSAGE_PARAM_KEYS } from '../messageParams';
+
+describe('filterMessageParams', () => {
+  it('keeps known SDK contract keys', () => {
+    const input = {
+      clientId: '0xabc',
+      redirectUri: 'https://app.example.com',
+      brandName: 'GM',
+      permissions: '1,2,3',
+      transactionData: { foo: 'bar' },
+    };
+    expect(filterMessageParams(input)).toEqual(input);
+  });
+
+  it('drops keys outside the allowlist', () => {
+    const result = filterMessageParams({
+      clientId: '0xabc',
+      somethingMalicious: 'pwn',
+    });
+    expect(result).toEqual({ clientId: '0xabc' });
+    expect('somethingMalicious' in result).toBe(false);
+  });
+
+  it('drops internal control flags that must never come from the wire', () => {
+    const result = filterMessageParams({
+      clientId: '0xabc',
+      waitingForDevLicense: false,
+      invalidCredentials: false,
+      oemBrand: { name: 'EvilCorp', logoUrl: 'https://evil/logo.svg' },
+      devLicenseAlias: 'spoofed',
+    });
+    expect(result).toEqual({ clientId: '0xabc' });
+  });
+
+  it('returns an empty object when nothing is allowlisted', () => {
+    expect(filterMessageParams({ junk: 1, more: 2 })).toEqual({});
+  });
+
+  it('allowlist covers the keys the app acts on', () => {
+    // Guards against accidentally dropping a legitimate flow's key.
+    [
+      'clientId',
+      'redirectUri',
+      'brandName',
+      'entryState',
+      'permissionTemplateId',
+      'permissions',
+      'vehicles',
+      'vehicleMakes',
+      'powertrainTypes',
+      'expirationDate',
+      'region',
+      'onboarding',
+      'cloudEvent',
+      'transactionData',
+      'messageData',
+    ].forEach((key) => expect(ALLOWED_MESSAGE_PARAM_KEYS.has(key)).toBe(true));
+  });
+});

--- a/src/utils/messageParams.ts
+++ b/src/utils/messageParams.ts
@@ -1,0 +1,59 @@
+/**
+ * messageParams.ts
+ *
+ * Defense-in-depth schema enforcement for inbound SDK postMessage payloads.
+ *
+ * `handleAuthInitMessage` receives `event.data` from the relying party and
+ * spreads it into `devCredentialsState`. Without filtering, any sender could
+ * write arbitrary keys — including internal control flags (`waitingForDevLicense`,
+ * `invalidCredentials`) or the resolved `oemBrand` record — straight into state,
+ * bypassing the values the app computes itself.
+ *
+ * This allowlist pins the inbound message to the keys the app actually acts on:
+ * the `specialSetters` in `useParamsHandler` plus the generic param fields in
+ * `types/params.ts`. Internal/computed fields (`waitingForParams`,
+ * `waitingForDevLicense`, `invalidCredentials`, `devLicenseAlias`, `oemBrand`)
+ * are deliberately excluded — they are never accepted from the wire.
+ */
+
+export const ALLOWED_MESSAGE_PARAM_KEYS = new Set<string>([
+  // Identity / routing
+  'clientId',
+  'redirectUri',
+  'apiKey',
+  'utm',
+  'configCID',
+  'entryState',
+  'brandName',
+  // UI behavior
+  'altTitle',
+  'forceEmail',
+  'newVehicleSectionDescription',
+  'shareVehiclesSectionDescription',
+  // Vehicle sharing flow
+  'permissionTemplateId',
+  'permissions',
+  'vehicles',
+  'vehicleTokenIds',
+  'vehicleMakes',
+  'powertrainTypes',
+  'expirationDate',
+  'region',
+  'onboarding',
+  'cloudEvent',
+  // Advanced transaction / sign message flows
+  'transactionData',
+  'messageData',
+]);
+
+/**
+ * Returns a copy of `params` containing only allowlisted keys. Unknown keys and
+ * internal control flags are dropped.
+ */
+export function filterMessageParams(
+  params: Record<string, unknown>,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(params).filter(([key]) => ALLOWED_MESSAGE_PARAM_KEYS.has(key)),
+  );
+}

--- a/src/utils/messageParams.ts
+++ b/src/utils/messageParams.ts
@@ -14,10 +14,21 @@
  * `types/params.ts`. Internal/computed fields (`waitingForParams`,
  * `waitingForDevLicense`, `invalidCredentials`, `devLicenseAlias`, `oemBrand`)
  * are deliberately excluded — they are never accepted from the wire.
+ *
+ * Verified against the login-with-dimo SDK (sdk/src/utils/eventHandler.ts):
+ *   AUTH_INIT message → clientId, redirectUri, apiKey, entryState, forceEmail,
+ *                       brandName, altTitle
+ *   action message    → DimoActionPayload: permissionTemplateId, vehicles,
+ *                       vehicleMakes, onboarding, expirationDate, utm,
+ *                       powertrainTypes, permissions, transactionData, messageData
+ * Every SDK-sent key is covered below. The remaining keys (configCID, region,
+ * cloudEvent, vehicleTokenIds, *SectionDescription) are app-side params from the
+ * config-CID/configurationId flows or special-setter aliases (vehicles →
+ * vehicleTokenIds), not sent over postMessage but kept as legitimate state.
  */
 
 export const ALLOWED_MESSAGE_PARAM_KEYS = new Set<string>([
-  // Identity / routing
+  // Identity / routing  (SDK AUTH_INIT: clientId, redirectUri, apiKey, entryState)
   'clientId',
   'redirectUri',
   'apiKey',
@@ -25,12 +36,12 @@ export const ALLOWED_MESSAGE_PARAM_KEYS = new Set<string>([
   'configCID',
   'entryState',
   'brandName',
-  // UI behavior
+  // UI behavior  (SDK AUTH_INIT: altTitle, forceEmail)
   'altTitle',
   'forceEmail',
   'newVehicleSectionDescription',
   'shareVehiclesSectionDescription',
-  // Vehicle sharing flow
+  // Vehicle sharing flow  (SDK action payload)
   'permissionTemplateId',
   'permissions',
   'vehicles',
@@ -41,7 +52,7 @@ export const ALLOWED_MESSAGE_PARAM_KEYS = new Set<string>([
   'region',
   'onboarding',
   'cloudEvent',
-  // Advanced transaction / sign message flows
+  // Advanced transaction / sign message flows  (SDK action payload)
   'transactionData',
   'messageData',
 ]);


### PR DESCRIPTION
## What

`handleAuthInitMessage` spread the **entire** SDK postMessage payload into `devCredentialsState`. Since a `postMessage` can come from any window, a sender could write arbitrary keys — including internal control flags (`waitingForDevLicense`, `invalidCredentials`) and the resolved `oemBrand` record — straight into state, bypassing values the app computes itself.

This adds an **allowlist** (`src/utils/messageParams.ts`) of the keys the app actually acts on (the `useParamsHandler` `specialSetters` + the param fields in `types/params.ts`). Unknown keys and internal/computed fields are dropped before the payload reaches state. `customParams` is app-computed and stays unfiltered.

## Scope (Layer 2 of 3)

This is **defense-in-depth schema enforcement**, not sender authentication. Two related hardenings are intentionally **out of scope** here (separate pass):

- **L1 — origin/source pinning** (`event.source === window.opener` + `document.referrer` origin check). Needs a live popup test rig before landing.
- **`sendMessageToReferrer` targetOrigin** posts to the parent with the *login app's own* origin (`messageHandler.ts:18`) — suspected bug, needs investigation first.

`clientId`/`redirectUri` remain trust-anchored downstream by `isValidDeveloperLicense` — unchanged.

## Tests

- `src/utils/__tests__/messageParams.test.ts` — pure allowlist filter (keeps contract keys, drops unknown + internal flags).
- `src/context/__tests__/DevCredentialsContext.test.tsx` — integration: an injected non-allowlisted key in `AUTH_INIT` does **not** land in context state; brand-forwarding tests still pass.

10/10 green. `tsc` clean on `src/`, lint clean. (Pre-existing `vehicleService`/`vehicle` suite-level failures are unrelated ESM-transform issues on `main`.)