### PR TITLE
fix(account): correct asset-DID chain + show success screen (popup no longer auto-closes)

### DIFF
--- a/src/components/Accounts/AccountPermissionsSuccess.tsx
+++ b/src/components/Accounts/AccountPermissionsSuccess.tsx
@@ -31,7 +31,7 @@ export const AccountPermissionsSuccess: React.FC = () => {
           driver's license and insurance card until you revoke access.
         </p>
       </div>
-      <div className="flex fex-col">
+      <div className="flex flex-col">
         {!isEmbed() && (
           <div className="flex justify-center w-full">
             <PrimaryButton onClick={handleBackToThirdParty} width="sm:w-64 w-full">

--- a/src/hooks/useFinishShareAccounts.tsx
+++ b/src/hooks/useFinishShareAccounts.tsx
@@ -1,23 +1,20 @@
-import { useDevCredentials } from '../context/DevCredentialsContext';
-import { AccountManagerMandatoryParams } from '../types';
 import { useUIManager } from '../context/UIManagerContext';
 import { useSendAuthPayloadToParent } from './useSendAuthPayloadToParent';
 import { UiStates } from '../enums';
-import { backToThirdParty } from '../utils/messageHandler';
 
-// Account-sharing analogue of useFinishShareVehicles: surfaces accountGranted +
-// transactionHash to the parent, then advances to the success screen (popup) or
-// redirects back to the third party (redirect mode, no transactionHash).
+// Account-sharing analogue of useFinishShareVehicles: surfaces accountGranted to
+// the parent, then shows the success screen. AccountPermissionsSuccess owns the
+// "Back to <app>" return action (and embedders navigate themselves), so we must
+// NOT call backToThirdParty here — doing so closed the popup before the success
+// screen was ever shown.
 export const useFinishShareAccounts = () => {
-  const { redirectUri, utm } = useDevCredentials<AccountManagerMandatoryParams>();
   const { setUiState, setComponentData } = useUIManager();
   const sendAuthPayloadToParent = useSendAuthPayloadToParent();
 
-  return (transactionHash?: string) => {
-    sendAuthPayloadToParent({ accountGranted: true, transactionHash }, (authPayload) => {
+  return () => {
+    sendAuthPayloadToParent({ accountGranted: true }, () => {
       setComponentData({ action: 'account-shared' });
       setUiState(UiStates.ACCOUNT_PERMISSIONS_SUCCESS);
-      if (!transactionHash) backToThirdParty(authPayload, redirectUri, utm);
     });
   };
 };

--- a/src/services/turnkeyService.ts
+++ b/src/services/turnkeyService.ts
@@ -196,14 +196,18 @@ export const generateIpfsSources = async (
 };
 
 // Account-level SACD source: grants document cloudevents on the user's account
-// DID (did:ethr:137:<grantor>), not on a vehicle. Mirrors generateIpfsSources but
-// carries the driver-document agreements and the correct account asset DID.
+// DID (did:ethr:<chainId>:<grantor>), not on a vehicle. Mirrors generateIpfsSources
+// but carries the driver-document agreements and the correct account asset DID.
 export const generateAccountIpfsSource = async (
   permissions: Permission[],
   clientId: `0x${string}` | null,
   expiration: BigInt,
 ): Promise<string> => {
   const grantor = kernelSigner.smartContractAddress!;
+  // Use the signer's actual chain (polygon=137 in prod, polygonAmoy=80002 in dev)
+  // so the asset DID matches the chain the grant is executed on — hardcoding 137
+  // orphaned the grant on non-prod environments.
+  const chainId = kernelSigner.chain.id;
   const ipfsRes = await withTimeout(
     kernelSigner.signAndUploadSACDAgreement({
       expiration,
@@ -211,7 +215,7 @@ export const generateAccountIpfsSource = async (
       grantee: clientId as `0x${string}`,
       attachments: [],
       grantor,
-      asset: `did:ethr:137:${grantor}`,
+      asset: `did:ethr:${chainId}:${grantor}`,
       cloudEventAgreements: buildDriverDocAgreements(grantor),
     }),
     KERNEL_OP_TIMEOUT_MS,


### PR DESCRIPTION
Follow-up to #294, fixing the two verified account-flow bugs before the login-with-dimo SDK is published (which activates this flow).

### #3 — hardcoded chain `137` in the account asset DID
`generateAccountIpfsSource` built `did:ethr:137:<grantor>`, but the kernel signer runs on **polygonAmoy (80002)** in dev/non-prod. The grant was executed on Amoy while the SACD asset claimed 137 — an orphaned grant on every non-prod env. Now uses `kernelSigner.chain.id` so the asset DID always matches the chain the grant executes on.

### #2 — popup closed before the success screen (dead code)
`useFinishShareAccounts` called `backToThirdParty(...)` whenever `transactionHash` was falsy — and it was **always** undefined (the `setAccountPermissions` bridge returns `void`), so it fired on every grant and closed the popup *before* `AccountPermissionsSuccess` (which has the "Back to <app>" button) was ever shown. Now mirrors the vehicle flow (`useFinishShareVehicles`): show the success screen and let it own the return; embedders navigate themselves. The `accountGranted` payload is still sent to the parent first.

Also fixes a `fex-col` → `flex-col` typo in the now-visible success screen.

### Verification
`src/` typechecks clean, `CI=true craco build` exits 0, `react-scripts test` 25/25. No change to live vehicle/login paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)