### PR TITLE
debug(account): surface real 'Failed to share documents' error

### DIFF
--- a/src/components/Accounts/AccountManager.tsx
+++ b/src/components/Accounts/AccountManager.tsx
@@ -32,9 +32,15 @@ export const AccountManager: React.FC = () => {
       await shareAccounts();
       finishShareAccounts();
     } catch (err) {
+      // Log the real error to the console — captureException ships it to Sentry,
+      // but that request is often blocked (content blockers/CORS), leaving only
+      // the opaque "Failed to share documents". This makes the cause legible.
+      // eslint-disable-next-line no-console
+      console.error('Account document sharing failed:', err);
       captureException(err);
       if (!isInvalidSessionError(err)) {
-        setError('Failed to share documents');
+        const detail = err instanceof Error ? err.message : String(err);
+        setError(`Failed to share documents: ${detail}`);
       }
     } finally {
       setLoadingState(false);


### PR DESCRIPTION
AccountManager only sent the error to Sentry (often blocked by content blockers/CORS) and showed an opaque 'Failed to share documents'. This logs the real error to the console and includes err.message in the UI so the actual cause (paymaster/simulation/signature) is legible while we diagnose the account-grant failure.