### PR TITLE
fix(account): Invalid Date crash in document sharing (undefined expiration)

### DIFF
--- a/src/hooks/useParamsHandler.ts
+++ b/src/hooks/useParamsHandler.ts
@@ -95,10 +95,14 @@ export const useParamsHandler = (DEFAULT_CONTEXT: AllParams) => {
 
   const applyDevCredentialsConfig = (config: Record<string, unknown>) => {
     Object.entries(config).forEach(([key, value]) => {
+      // An incoming `undefined` means "not provided" by the SDK payload — never
+      // write it, or it clobbers the defaults in DEFAULT_CONTEXT. (e.g. a missing
+      // expirationDate would overwrite the 100-year default with undefined, which
+      // the account SACD builder then feeds to `new Date()` → "Invalid Date".)
+      if (value === undefined) return;
       if (
         key in specialSetters &&
-        specialSetters[key as keyof typeof specialSetters] &&
-        value !== undefined
+        specialSetters[key as keyof typeof specialSetters]
       ) {
         specialSetters[key as keyof typeof specialSetters](value);
       } else {

--- a/src/hooks/useShareAccounts.ts
+++ b/src/hooks/useShareAccounts.ts
@@ -3,6 +3,7 @@ import { generateAccountIpfsSource, setAccountPermissions } from '../services';
 import { useDevCredentials } from '../context/DevCredentialsContext';
 import { useAuthContext } from '../context/AuthContext';
 import { INVALID_SESSION_ERROR } from '../utils/authUtils';
+import { getDefaultExpirationDate } from '../utils/dateUtils';
 import { AccountManagerMandatoryParams } from '../types';
 
 // Account-sharing analogue of useShareVehicles: signs an account-level SACD
@@ -17,16 +18,21 @@ export const useShareAccounts = () => {
     const valid = !!(await validateSession());
     if (!valid) throw new Error(INVALID_SESSION_ERROR);
 
+    // Guarantee a valid expiration even if the param plumbing ever delivers
+    // undefined — the SACD builder does `new Date(Number(expiration) * 1000)`,
+    // and undefined → NaN → Invalid Date → RangeError on toISOString().
+    const expiration = expirationDate ?? getDefaultExpirationDate();
+
     const permissions = [Permission.GetRawData];
     const source = await generateAccountIpfsSource(
       permissions,
       clientId,
-      expirationDate,
+      expiration,
     );
     await setAccountPermissions({
       grantee: clientId as `0x${string}`,
       permissions,
-      expiration: expirationDate,
+      expiration,
       // BigInt(0); the project targets es5 so 0n literals aren't available.
       templateId: BigInt(0),
       source,


### PR DESCRIPTION
Fixes 'Failed to share documents' = RangeError: Invalid Date in the SACD builder (setPermissionsSACD toISOString). A missing expirationDate from the SDK payload was clobbering the 100-year default with undefined, which the builder fed to new Date() -> NaN. Two fixes: applyDevCredentialsConfig no longer writes undefined over defaults; useShareAccounts defaults the expiration. Build + 25 tests green.